### PR TITLE
feat: Make analyzeAll async with streaming per-file diagnostics

### DIFF
--- a/server/src/bridge.rs
+++ b/server/src/bridge.rs
@@ -11,7 +11,7 @@ use tokio::time;
 
 use crate::config::Config;
 use crate::error::{BridgeError, Error};
-use crate::jsonrpc::{self, Request, Response};
+use crate::jsonrpc::{self, Message, Notification, Request, Response};
 
 /// Sidecar lifecycle states.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -58,6 +58,8 @@ pub struct Bridge {
     child: Mutex<Option<tokio::process::Child>>,
     /// Stored init params for automatic restart.
     init_params: Mutex<InitParams>,
+    /// Channel sender for forwarding sidecar notifications to subscribers.
+    notification_tx: Arc<Mutex<Option<mpsc::Sender<Notification>>>>,
 }
 
 impl Bridge {
@@ -86,6 +88,7 @@ impl Bridge {
             health_check_shutdown: Arc::new(Notify::new()),
             child: Mutex::new(None),
             init_params: Mutex::new(InitParams::default()),
+            notification_tx: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -293,12 +296,13 @@ impl Bridge {
             });
         }
 
-        // Spawn the reader task to process incoming responses
+        // Spawn the reader task to process incoming responses and notifications
         let pending = Arc::clone(&self.pending);
         let state = Arc::clone(&self.state);
         let state_watch_tx = Arc::clone(&self.state_watch_tx);
         let shutdown = Arc::clone(&self.shutdown_notify);
         let reader_bridge = Arc::clone(self);
+        let notification_tx = Arc::clone(&self.notification_tx);
 
         tokio::spawn(async move {
             let mut reader = BufReader::new(stdout);
@@ -308,9 +312,16 @@ impl Bridge {
                 tokio::select! {
                     result = jsonrpc::read_message(&mut reader) => {
                         match result {
-                            Ok(Some(response)) => {
-                                tracing::debug!("Read message from sidecar");
+                            Ok(Some(Message::Response(response))) => {
+                                tracing::debug!("Read response from sidecar");
                                 Self::dispatch_response(&pending, response).await;
+                            }
+                            Ok(Some(Message::Notification(notification))) => {
+                                tracing::debug!("Read notification from sidecar: {}", notification.method);
+                                let tx = notification_tx.lock().await;
+                                if let Some(ref sender) = *tx {
+                                    let _ = sender.send(notification).await;
+                                }
                             }
                             Ok(None) => {
                                 // EOF - sidecar exited. Cancel all pending requests immediately.
@@ -623,6 +634,15 @@ impl Bridge {
                 }
             }
         })
+    }
+
+    /// Subscribes to sidecar notifications (JSON-RPC messages with method but no id).
+    /// Returns a receiver that yields notifications as they arrive from the sidecar.
+    pub async fn subscribe_notifications(&self) -> mpsc::Receiver<Notification> {
+        let (tx, rx) = mpsc::channel(64);
+        let mut slot = self.notification_tx.lock().await;
+        *slot = Some(tx);
+        rx
     }
 
     /// Shuts down the sidecar gracefully.

--- a/server/src/jsonrpc.rs
+++ b/server/src/jsonrpc.rs
@@ -36,6 +36,20 @@ pub struct ResponseError {
     pub data: Option<serde_json::Value>,
 }
 
+/// JSON-RPC 2.0 notification from the sidecar (no id, has method).
+#[derive(Debug, Clone)]
+pub struct Notification {
+    pub method: String,
+    pub params: Option<serde_json::Value>,
+}
+
+/// A message from the sidecar: either a response to a request or an unsolicited notification.
+#[derive(Debug)]
+pub enum Message {
+    Response(Response),
+    Notification(Notification),
+}
+
 impl Request {
     pub fn new(id: u64, method: &str, params: Option<serde_json::Value>) -> Self {
         Self {
@@ -79,9 +93,10 @@ pub async fn write_message(
 
 /// Reads a JSON-RPC message with Content-Length framing from an async reader.
 /// Returns `None` on EOF (sidecar exited).
+/// Distinguishes between responses (have `id`) and notifications (have `method`, no `id`).
 pub async fn read_message(
     reader: &mut BufReader<ChildStdout>,
-) -> Result<Option<Response>, crate::error::Error> {
+) -> Result<Option<Message>, crate::error::Error> {
     let content_length = match read_content_length(reader).await? {
         Some(len) => len,
         None => return Ok(None), // EOF
@@ -94,9 +109,18 @@ pub async fn read_message(
         Err(e) => return Err(crate::error::Error::Io(e)),
     }
 
-    let response: Response = serde_json::from_slice(&body).map_err(ProtocolError::JsonParse)?;
+    let value: serde_json::Value =
+        serde_json::from_slice(&body).map_err(ProtocolError::JsonParse)?;
 
-    Ok(Some(response))
+    // Notifications have a "method" field but no "id" field
+    if value.get("method").is_some() && value.get("id").is_none() {
+        let method = value["method"].as_str().unwrap_or("").to_string();
+        let params = value.get("params").cloned();
+        Ok(Some(Message::Notification(Notification { method, params })))
+    } else {
+        let response: Response = serde_json::from_value(value).map_err(ProtocolError::JsonParse)?;
+        Ok(Some(Message::Response(response)))
+    }
 }
 
 /// Reads headers until the empty line separator, extracts Content-Length.

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -818,7 +818,7 @@ impl LanguageServer for KotlinLanguageServer {
                         }
                     }
 
-                    // --- Project-wide background analysis ---
+                    // --- Project-wide background analysis (streaming) ---
                     let bg_bridge = Arc::clone(&bridge_holder);
                     let bg_documents = Arc::clone(&documents_holder);
                     let bg_client = client.clone();
@@ -858,150 +858,15 @@ impl LanguageServer for KotlinLanguageServer {
                             )
                             .await;
 
-                        // Call analyzeAll with a generous timeout (5 minutes)
                         let bridge_arc = {
                             let guard = bg_bridge.lock().await;
                             guard.as_ref().map(Arc::clone)
                         };
-                        let analyze_result = match bridge_arc {
-                            Some(b) => {
-                                if b.state().await != SidecarState::Ready {
-                                    tracing::warn!(
-                                        "background analysis: sidecar not ready, skipping"
-                                    );
-                                    None
-                                } else {
-                                    Some(
-                                        b.request_with_timeout(
-                                            "analyzeAll",
-                                            None,
-                                            Duration::from_secs(300),
-                                        )
-                                        .await,
-                                    )
-                                }
-                            }
-                            None => None,
-                        };
 
-                        match analyze_result {
-                            Some(Ok(result)) => {
-                                let files = result.get("files").and_then(|f| f.as_array());
-                                let total_files = result
-                                    .get("totalFiles")
-                                    .and_then(|t| t.as_u64())
-                                    .unwrap_or(0);
-                                let total_errors = result
-                                    .get("totalErrors")
-                                    .and_then(|e| e.as_u64())
-                                    .unwrap_or(0);
-                                let total_warnings = result
-                                    .get("totalWarnings")
-                                    .and_then(|w| w.as_u64())
-                                    .unwrap_or(0);
-
-                                if let Some(files) = files {
-                                    let mut processed = 0u64;
-                                    let mut _published = 0u64;
-                                    for file_entry in files {
-                                        processed += 1;
-
-                                        let uri_str =
-                                            match file_entry.get("uri").and_then(|u| u.as_str()) {
-                                                Some(u) => u,
-                                                None => continue,
-                                            };
-
-                                        let uri = match Url::parse(uri_str) {
-                                            Ok(u) => u,
-                                            Err(e) => {
-                                                tracing::warn!("background analysis: invalid URI from sidecar: {:?} ({})", uri_str, e);
-                                                continue;
-                                            }
-                                        };
-
-                                        // Skip files that are currently open — their diagnostics
-                                        // from the replay loop are fresher
-                                        {
-                                            let docs = bg_documents.lock().await;
-                                            if docs.get(&uri).is_some() {
-                                                continue;
-                                            }
-                                        }
-
-                                        let diagnostics = parse_diagnostics_static(file_entry);
-
-                                        // Only publish and cache files with actual diagnostics
-                                        if !diagnostics.is_empty() {
-                                            {
-                                                let mut docs = bg_documents.lock().await;
-                                                docs.set_diagnostics(
-                                                    uri.clone(),
-                                                    diagnostics.clone(),
-                                                );
-                                            }
-                                            bg_client
-                                                .publish_diagnostics(uri, diagnostics, None)
-                                                .await;
-                                            _published += 1;
-                                        }
-
-                                        // Report progress periodically
-                                        if total_files > 0 && processed % 10 == 0 {
-                                            let pct = ((processed as f64 / total_files as f64)
-                                                * 100.0)
-                                                as u32;
-                                            bg_client
-                                                .send_notification::<lsp_types::notification::Progress>(ProgressParams {
-                                                    token: bg_token.clone(),
-                                                    value: ProgressParamsValue::WorkDone(WorkDoneProgress::Report(
-                                                        WorkDoneProgressReport {
-                                                            message: Some(format!("Processed {}/{} files", processed, total_files)),
-                                                            percentage: Some(pct),
-                                                            cancellable: Some(false),
-                                                        },
-                                                    )),
-                                                })
-                                                .await;
-                                        }
-                                    }
-
-                                    let summary = format!(
-                                        "Complete — {} error(s), {} warning(s) in {} file(s)",
-                                        total_errors, total_warnings, total_files
-                                    );
-                                    tracing::info!("background analysis: {}", summary);
-
-                                    bg_client
-                                        .send_notification::<lsp_types::notification::Progress>(
-                                            ProgressParams {
-                                                token: bg_token.clone(),
-                                                value: ProgressParamsValue::WorkDone(
-                                                    WorkDoneProgress::End(WorkDoneProgressEnd {
-                                                        message: Some(summary),
-                                                    }),
-                                                ),
-                                            },
-                                        )
-                                        .await;
-                                }
-                            }
-                            Some(Err(e)) => {
-                                tracing::warn!("background analysis failed: {}", e);
-                                bg_client
-                                    .send_notification::<lsp_types::notification::Progress>(
-                                        ProgressParams {
-                                            token: bg_token.clone(),
-                                            value: ProgressParamsValue::WorkDone(
-                                                WorkDoneProgress::End(WorkDoneProgressEnd {
-                                                    message: Some(format!("Failed: {}", e)),
-                                                }),
-                                            ),
-                                        },
-                                    )
-                                    .await;
-                            }
-                            None => {
+                        let bridge = match bridge_arc {
+                            Some(b) if b.state().await == SidecarState::Ready => b,
+                            _ => {
+                                tracing::warn!("background analysis: sidecar not ready, skipping");
                                 bg_client
                                     .send_notification::<lsp_types::notification::Progress>(
                                         ProgressParams {
@@ -1016,8 +881,202 @@ impl LanguageServer for KotlinLanguageServer {
                                         },
                                     )
                                     .await;
+                                return;
+                            }
+                        };
+
+                        // Subscribe to streaming notifications before sending analyzeAll
+                        let mut notification_rx = bridge.subscribe_notifications().await;
+
+                        // Send analyzeAll — sidecar returns an immediate ack and streams
+                        // per-file diagnostics as "diagnostics/progress" notifications
+                        match bridge.request("analyzeAll", None).await {
+                            Ok(_ack) => {
+                                tracing::debug!("background analysis: analyzeAll ack received, consuming streaming notifications");
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "background analysis: analyzeAll request failed: {}",
+                                    e
+                                );
+                                bg_client
+                                    .send_notification::<lsp_types::notification::Progress>(
+                                        ProgressParams {
+                                            token: bg_token.clone(),
+                                            value: ProgressParamsValue::WorkDone(
+                                                WorkDoneProgress::End(WorkDoneProgressEnd {
+                                                    message: Some(format!("Failed: {}", e)),
+                                                }),
+                                            ),
+                                        },
+                                    )
+                                    .await;
+                                return;
                             }
                         }
+
+                        // Consume streaming diagnostics/progress notifications
+                        let mut total_errors = 0u64;
+                        let mut total_warnings = 0u64;
+                        let mut processed = 0u64;
+                        let mut total_files = 0u64;
+
+                        // Use a 5-minute overall timeout for the streaming phase
+                        let deadline = tokio::time::Instant::now() + Duration::from_secs(300);
+
+                        loop {
+                            match tokio::time::timeout_at(deadline, notification_rx.recv()).await {
+                                Ok(Some(notification))
+                                    if notification.method == "diagnostics/progress" =>
+                                {
+                                    let params = match notification.params {
+                                        Some(p) => p,
+                                        None => continue,
+                                    };
+
+                                    // Extract progress info
+                                    if let Some(progress) = params.get("progress") {
+                                        total_files = progress
+                                            .get("total")
+                                            .and_then(|t| t.as_u64())
+                                            .unwrap_or(total_files);
+                                    }
+                                    processed += 1;
+
+                                    let uri_str = match params.get("uri").and_then(|u| u.as_str()) {
+                                        Some(u) => u,
+                                        None => continue,
+                                    };
+
+                                    let uri = match Url::parse(uri_str) {
+                                        Ok(u) => u,
+                                        Err(e) => {
+                                            tracing::warn!("background analysis: invalid URI from sidecar: {:?} ({})", uri_str, e);
+                                            continue;
+                                        }
+                                    };
+
+                                    // Skip files that are currently open
+                                    {
+                                        let docs = bg_documents.lock().await;
+                                        if docs.get(&uri).is_some() {
+                                            // Check if we're done
+                                            if let Some(progress) = params.get("progress") {
+                                                let current = progress
+                                                    .get("current")
+                                                    .and_then(|c| c.as_u64())
+                                                    .unwrap_or(0);
+                                                let total = progress
+                                                    .get("total")
+                                                    .and_then(|t| t.as_u64())
+                                                    .unwrap_or(0);
+                                                if total > 0 && current >= total {
+                                                    break;
+                                                }
+                                            }
+                                            continue;
+                                        }
+                                    }
+
+                                    let diagnostics = parse_diagnostics_static(&params);
+
+                                    // Count errors and warnings
+                                    for d in &diagnostics {
+                                        match d.severity {
+                                            Some(lsp_types::DiagnosticSeverity::ERROR) => {
+                                                total_errors += 1
+                                            }
+                                            Some(lsp_types::DiagnosticSeverity::WARNING) => {
+                                                total_warnings += 1
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+
+                                    // Only publish files with actual diagnostics
+                                    if !diagnostics.is_empty() {
+                                        {
+                                            let mut docs = bg_documents.lock().await;
+                                            docs.set_diagnostics(uri.clone(), diagnostics.clone());
+                                        }
+                                        bg_client.publish_diagnostics(uri, diagnostics, None).await;
+                                    }
+
+                                    // Report progress periodically
+                                    if total_files > 0 && processed % 10 == 0 {
+                                        let pct = ((processed as f64 / total_files as f64) * 100.0)
+                                            .min(100.0)
+                                            as u32;
+                                        bg_client
+                                            .send_notification::<lsp_types::notification::Progress>(
+                                                ProgressParams {
+                                                    token: bg_token.clone(),
+                                                    value: ProgressParamsValue::WorkDone(
+                                                        WorkDoneProgress::Report(
+                                                            WorkDoneProgressReport {
+                                                                message: Some(format!(
+                                                                    "Processed {}/{} files",
+                                                                    processed, total_files
+                                                                )),
+                                                                percentage: Some(pct),
+                                                                cancellable: Some(false),
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                            )
+                                            .await;
+                                    }
+
+                                    // Check if this was the last file
+                                    if let Some(progress) = params.get("progress") {
+                                        let current = progress
+                                            .get("current")
+                                            .and_then(|c| c.as_u64())
+                                            .unwrap_or(0);
+                                        let total = progress
+                                            .get("total")
+                                            .and_then(|t| t.as_u64())
+                                            .unwrap_or(0);
+                                        if total > 0 && current >= total {
+                                            break;
+                                        }
+                                    }
+                                }
+                                Ok(Some(_other)) => {
+                                    // Ignore non-diagnostics notifications
+                                }
+                                Ok(None) => {
+                                    tracing::warn!(
+                                        "background analysis: notification channel closed"
+                                    );
+                                    break;
+                                }
+                                Err(_) => {
+                                    tracing::warn!("background analysis: timed out waiting for streaming results");
+                                    break;
+                                }
+                            }
+                        }
+
+                        let summary = format!(
+                            "Complete — {} error(s), {} warning(s) in {} file(s)",
+                            total_errors, total_warnings, processed
+                        );
+                        tracing::info!("background analysis: {}", summary);
+
+                        bg_client
+                            .send_notification::<lsp_types::notification::Progress>(
+                                ProgressParams {
+                                    token: bg_token.clone(),
+                                    value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(
+                                        WorkDoneProgressEnd {
+                                            message: Some(summary),
+                                        },
+                                    )),
+                                },
+                            )
+                            .await;
                     });
                 }
                 Err(e) => {

--- a/sidecar/src/main/kotlin/dev/kouros/sidecar/AnalysisServer.kt
+++ b/sidecar/src/main/kotlin/dev/kouros/sidecar/AnalysisServer.kt
@@ -150,8 +150,23 @@ class AnalysisServer(
     }
 
     private fun handleAnalyzeAll(request: JsonRpcRequest) {
-        val result = bridge.analyzeAll()
-        transport.sendResult(request.id, result)
+        // Send immediate ack so the Rust LSP knows analysis has started
+        val ack = JsonObject()
+        ack.addProperty("started", true)
+        transport.sendResult(request.id, ack)
+
+        // Run analysis on a background thread, streaming per-file diagnostics
+        // as JSON-RPC notifications to avoid blocking the event loop
+        Thread({
+            try {
+                bridge.analyzeAllStreaming { notification ->
+                    transport.sendNotification("diagnostics/progress", notification)
+                }
+            } catch (e: Throwable) {
+                System.err.println("AnalysisServer: background analyzeAll failed: ${e.javaClass.name}: ${e.message}")
+                e.printStackTrace(System.err)
+            }
+        }, "analyzeAll-background").start()
     }
 
     private fun handleHover(request: JsonRpcRequest) {

--- a/sidecar/src/main/kotlin/dev/kouros/sidecar/CompilerBridge.kt
+++ b/sidecar/src/main/kotlin/dev/kouros/sidecar/CompilerBridge.kt
@@ -630,6 +630,113 @@ class CompilerBridge {
     }
 
     /**
+     * Analyzes all source files and streams per-file diagnostics via a callback.
+     * Each callback invocation receives a JsonObject with uri, diagnostics, and progress.
+     * Runs on the calling thread — the caller is responsible for running this on a
+     * background thread to avoid blocking the event loop.
+     */
+    fun analyzeAllStreaming(onFileAnalyzed: (JsonObject) -> Unit) {
+        val currentSession = session
+        if (currentSession == null) {
+            System.err.println("CompilerBridge: analyzeAllStreaming() — session is NULL, nothing to stream")
+            return
+        }
+
+        val allKtFiles = currentSession.modulesWithFiles.entries
+            .flatMap { (_, files) -> files }
+            .filterIsInstance<KtFile>()
+
+        // Filter out build scripts and build directories
+        val filesToAnalyze = allKtFiles.filter { ktFile ->
+            val filePath = ktFile.virtualFile.path
+            !filePath.endsWith(".gradle.kts") &&
+                !(filePath.endsWith(".kts") && ("/buildSrc/" in filePath || "/gradle/" in filePath)) &&
+                "/build/" !in filePath &&
+                "/.gradle/" !in filePath
+        }
+
+        val totalFiles = filesToAnalyze.size
+        System.err.println("CompilerBridge: analyzeAllStreaming() — $totalFiles file(s) to analyze")
+
+        var current = 0
+
+        for (ktFile in filesToAnalyze) {
+            current++
+            val filePath = ktFile.virtualFile.path
+            val fileUri = "file://$filePath"
+
+            // Use virtual content if the file is open in the editor
+            val effectiveKtFile = if (virtualFiles.containsKey(fileUri)) {
+                findKtFile(currentSession, fileUri) ?: ktFile
+            } else {
+                ktFile
+            }
+
+            val notification = JsonObject()
+            notification.addProperty("uri", fileUri)
+            val diagnosticsArray = JsonArray()
+
+            try {
+                analyze(effectiveKtFile) {
+                    val diagnostics = effectiveKtFile.collectDiagnostics(
+                        KaDiagnosticCheckerFilter.EXTENDED_AND_COMMON_CHECKERS
+                    )
+
+                    for (diagnostic in diagnostics) {
+                        val diagObj = JsonObject()
+                        diagObj.addProperty("severity", diagnostic.severity.name)
+                        diagObj.addProperty("message", diagnostic.defaultMessage)
+                        diagObj.addProperty("code", diagnostic.factoryName)
+
+                        val textRange = diagnostic.textRanges.firstOrNull()
+                        if (textRange != null) {
+                            try {
+                                val document = effectiveKtFile.viewProvider.document
+                                if (document != null) {
+                                    val startLine = document.getLineNumber(textRange.startOffset) + 1
+                                    val startLineOffset = document.getLineStartOffset(
+                                        document.getLineNumber(textRange.startOffset)
+                                    )
+                                    val startCol = textRange.startOffset - startLineOffset
+
+                                    val endLine = document.getLineNumber(textRange.endOffset) + 1
+                                    val endLineOffset = document.getLineStartOffset(
+                                        document.getLineNumber(textRange.endOffset)
+                                    )
+                                    val endCol = textRange.endOffset - endLineOffset
+
+                                    diagObj.addProperty("line", startLine)
+                                    diagObj.addProperty("column", startCol)
+                                    diagObj.addProperty("endLine", endLine)
+                                    diagObj.addProperty("endColumn", endCol)
+                                }
+                            } catch (_: Exception) {
+                                // Position extraction failed, skip position info
+                            }
+                        }
+
+                        diagnosticsArray.add(diagObj)
+                    }
+                }
+            } catch (e: Throwable) {
+                System.err.println("CompilerBridge: analyzeAllStreaming() — error analyzing $filePath: ${e.javaClass.name}: ${e.message}")
+            }
+
+            notification.add("diagnostics", diagnosticsArray)
+
+            // Add progress info
+            val progress = JsonObject()
+            progress.addProperty("current", current)
+            progress.addProperty("total", totalFiles)
+            notification.add("progress", progress)
+
+            onFileAnalyzed(notification)
+        }
+
+        System.err.println("CompilerBridge: analyzeAllStreaming() — completed $current/$totalFiles files")
+    }
+
+    /**
      * Provides hover information at the given position.
      * Returns type/signature information with KDoc documentation when available.
      */

--- a/sidecar/src/main/kotlin/dev/kouros/sidecar/JsonRpc.kt
+++ b/sidecar/src/main/kotlin/dev/kouros/sidecar/JsonRpc.kt
@@ -106,6 +106,27 @@ class JsonRpcTransport(
         )
     }
 
+    /**
+     * Sends a JSON-RPC notification (no id, no response expected).
+     * Used for streaming results like per-file diagnostics during analyzeAll.
+     */
+    fun sendNotification(method: String, params: JsonObject) {
+        val obj = JsonObject()
+        obj.addProperty("jsonrpc", "2.0")
+        obj.addProperty("method", method)
+        obj.add("params", params)
+
+        val json = gson.toJson(obj)
+        val bytes = json.toByteArray(Charsets.UTF_8)
+
+        synchronized(writer) {
+            writer.write("Content-Length: ${bytes.size}\r\n")
+            writer.write("\r\n")
+            writer.write(json)
+            writer.flush()
+        }
+    }
+
     private fun readContentLength(): Int? {
         var contentLength: Int? = null
 


### PR DESCRIPTION
## Summary

- **Problem**: `analyzeAll` blocked the sidecar's single-threaded event loop, making the editor unresponsive during project-wide analysis (could take minutes for large projects)
- **Solution**: The sidecar now returns an immediate ack and runs analysis on a background thread, streaming per-file diagnostics as JSON-RPC notifications
- **Result**: The editor remains responsive during analysis, and diagnostics appear incrementally as files are analyzed with real-time progress reporting

## Changes

### Rust LSP (server)
- `jsonrpc.rs`: Added `Notification` struct and `Message` enum to distinguish responses from unsolicited notifications
- `bridge.rs`: Added notification channel with `subscribe_notifications()` method; updated reader task to route notifications vs responses
- `server.rs`: Replaced blocking `analyzeAll` request with streaming notification consumer that publishes diagnostics incrementally

### JVM Sidecar
- `JsonRpc.kt`: Added `sendNotification()` method for JSON-RPC notifications (no id, no response expected)
- `CompilerBridge.kt`: Added `analyzeAllStreaming()` that iterates source files and emits per-file diagnostics via callback with progress info
- `AnalysisServer.kt`: `handleAnalyzeAll` now sends immediate ack, then runs `analyzeAllStreaming` on a background thread

## Protocol

The streaming protocol uses JSON-RPC notifications:

```json
{
  "jsonrpc": "2.0",
  "method": "diagnostics/progress",
  "params": {
    "uri": "file:///path/to/File.kt",
    "diagnostics": [...],
    "progress": { "current": 5, "total": 42 }
  }
}
```

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `sidecar ./gradlew shadowJar` passes
- [x] `sidecar ./gradlew test` passes (109 tests, pre-existing flaky RedeclarationPropertyTest excluded)
- [x] All pre-commit hooks pass (fmt, clippy, test)
- [ ] End-to-end verification: open Kotlin project in Zed, verify background analysis shows incremental progress and diagnostics appear as files are analyzed

🤖 Generated with [Claude Code](https://claude.com/claude-code)